### PR TITLE
add documentation and functionality for merging H5s of prediction across chromosomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md — variant-scorer
+
+This file is the entry point for any agent working in this codebase. Read it fully before writing or running any code.
+
+
+## Project Overview
+
+The `variant-scorer` repository provides a suite of tools to predict the functional impact of genetic variants (SNPs, insertions, deletions) using **ChromBPNet** deep learning models. It transforms genomic sequences into predicted chromatin accessibility profiles and quantifies the "disruption" caused by sequence alterations.
+
+The toolkit moves from raw variant lists to summarized, annotated effect sizes and contribution (SHAP) scores.
+
+## Repository Layout
+
+```text
+src/
+  variant_scoring.py           # Core script: predicts scores for variant alleles
+  variant_scoring.per_chrom.py # Memory-efficient scoring (per-chromosome)
+  variant_summary_across_folds.py # Aggregates results from multi-fold models
+  variant_annotation.py        # Overlaps variants with peaks, genes, or motifs
+  variant_shap.py              # Computes base-resolution contribution scores
+  
+output/                        # All script outputs (TSV, HDF5) should be directed here
+  {prefix}.variant_scores.tsv  # Standard output from scoring
+  {prefix}.variant_shap.h5     # SHAP contribution scores
+
+```
+
+## Data Specifications
+
+### Variant Input Schemas
+
+Variants must be provided as TSVs. The `--schema` argument defines the expected columns:
+
+| Schema | Columns |
+| --- | --- |
+| `chrombpnet` | `['chr', 'pos', 'allele1', 'allele2', 'variant_id']` |
+| `bed` | `['chr', 'pos', 'end', 'allele1', 'allele2', 'variant_id']` |
+| `plink` | `['chr', 'variant_id', 'ignore1', 'pos', 'allele1', 'allele2']` |
+| `original` | `['chr', 'pos', 'variant_id', 'allele1', 'allele2']` |
+
+> **Note on Indexing:** The `pos` column is **1-indexed** for all schemas except `bed`, which follows the standard 0-indexed BED convention.
+
+### Allele Representations
+
+* **SNPs:** `A`, `C`, `G`, `T` in both allele columns.
+* **Deletions:** Use `-` for `allele2`.
+* **Insertions:** Use `-` for `allele1`.
+
+## Key Metrics & Definitions
+
+Effect sizes are computed as `allele2` (variant) vs `allele1` (reference).
+
+* **`logfc`**: Log2 fold-change of total predicted coverage. Positive values indicate the variant increases accessibility.
+* **`jsd`**: Jensen-Shannon Distance. Measures how much the *shape* of the accessibility profile changes (e.g., a TF footprint disappearing), independent of total magnitude.
+* **`active_allele_quantile` (AAQ)**: Percentile of the stronger allele's coverage relative to all peaks in the training data.
+* **Integrative Scores**:
+* **IES (Integrative Effect Size)**: `abs_logfc * jsd`.
+* **IPS (Integrative Prioritization Score)**: `logfc * jsd * AAQ`.
+
+
+## Workflow & Execution
+
+### 1. Primary Scoring
+
+Use `variant_scoring.py` for standard runs. For large whole-genome lists, use `variant_scoring.per_chrom.py` to avoid OOM (Out of Memory) errors.
+
+
+### 2. Multi-Fold Aggregation
+
+ChromBPNet models are often trained in cross-validation folds. We average over the folds to improve robustness.
+
+
+### 3. Interpretation (SHAP)
+
+To see *why* a variant is scored highly, compute SHAP scores. This reveals which nucleotides (the variant itself or flanking motifs) drive the prediction.
+
+* **Outputs:** HDF5 file containing `raw/seq` (one-hot) and `projected_shap/seq` (importance values).
+
+## Technical Constraints
+
+* **Forward/Reverse Bias:** By default, predictions are averaged across the forward and reverse-complement sequences. Use `--forward_only` only if specifically required by the experimental design.
+* **Logits vs Probs:** Profile predictions are saved as **logits**. When averaging across folds, average the logits first, then apply softmax.
+* **Memory Management:** For large variant sets, always use `--no_hdf5` unless base-pair resolution bigwigs are strictly required for every variant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,9 @@ Or, to skip all the tests that require Oak data, use:
 ```bash
 pytest -rs -s -m "not oak"
 ```
+
+Or, run a specific test:
+
+```bash
+pytest -rs -s tests/test_variant_scoring.py::TestVariantScoringCLI::test_variant_scoring_per_chrom
+```

--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ chr1	866281	-	CT	1_866281_CTins
 ## 1. Score variants: `variant_scoring.py`
 
 This script takes a list of variants in various input formats and generates scores
-for the variants using a ChromBPNet model. The output is a TSV file containing the scores for each variant. 
-Since variants are stored in memory, we also provide `variant_scoring.per_chrom.py` to score variants on a per-chromosome basis,
-and write the scores per chromosome to file before proceeding to the next chromosome. Per-chromosome
-files can then be merged automatically using the `--merge` option.
+for the variants using a ChromBPNet model. The output is a TSV file containing the scores for each variant.
 
 ### Usage:
 
@@ -81,7 +78,6 @@ python src/variant_scoring.py --list [VARIANTS_FILE] \
 - `-m`, `--model` (**required**): Path to the ChromBPNet model .h5 file to use for variant scoring. For most use cases, this should be the bias-corrected model (chrombpnet_nobias.h5)
 - `-o`, `--out_prefix` (**required**): Output prefix for storing SNP effect score predictions from the script, in the form of `<path>/<prefix>`. Directory should already exist.
 - `-s`, `--chrom_sizes` (**required**): Path to TSV file with chromosome sizes
-- `--no_hdf5`: Do not save basepair resolution predictions to hdf5 file. Recommended for large variant lists.
 - `-ps`, `--peak_chrom_sizes`: Path to TSV file with chromosome sizes for peak genome
 - `-b`, `--bias`: Bias model to use for variant scoring
 - `-li`, `--lite`: Models were trained with chrombpnet-lite
@@ -94,11 +90,12 @@ python src/variant_scoring.py --list [VARIANTS_FILE] \
 - `-mp`, `--max_peaks`: Maximum number of peaks to use for peak percentile calculation
 - `-c`, `--chrom`: Only score SNPs in selected chromosome
 - `-r`, `--random_seed`: Random seed for reproducibility when sampling
-- `--no_hdf5`: Do not save detailed predictions in hdf5 file
 - `-nc`, `--num_chunks`: Number of chunks to divide SNP file into
 - `-fo`, `--forward_only`: Run variant scoring only on forward sequence (Default: False)
 - `-st`, `--shap_type`: ChromBPNet output for which SHAP values should be computed (`counts` or `profile`). Default is `counts`
 - `-sh`, `--shuffled_scores`: Path to pre-computed shuffled scores
+- `--no_hdf5`: Do not save base-pair resolution predictions to HDF5 file. Recommended for large variant lists.
+- `--merge`: Merge all per-chromosome output files into a single file, then delete the per-chromosome files. Only relevant when using `variant_scoring.per_chrom.py`. Default: False.
 
 
 
@@ -126,6 +123,29 @@ We provide several additional metrics that are computed as the product of the ab
 *__NOTE__*: For profile predictions, the saved arrays consist of model logits, not probabilities. This allows for averaging profile predictions across folds more easily, by averaging logits over folds and then taking the softmax (see [`variant-scorer/pull/23`](https://github.com/kundajelab/variant-scorer/pull/23)).
 
 
+### Per-chromosome scoring for large variant sets: `variant_scoring.per_chrom.py`
+
+For large variant lists, `variant_scoring.per_chrom.py` runs scoring per chromosome, which allows for parallelization and lower memory usage.
+
+It accepts the same arguments as `variant_scoring.py`. The key additional argument is:
+
+- `--merge`: After all chromosomes are scored, concatenate the per-chromosome output files into a single merged file and delete the per-chromosome files. Without `--merge`, per-chromosome files are left on disk for manual inspection or merging.
+
+#### Outputs
+
+Without `--merge`, outputs are written per chromosome:
+
+- `<out_prefix>.<chrom>.variant_scores.tsv` — scores for variants on that chromosome
+- `<out_prefix>.<chrom>.variant_predictions.h5` — base-pair resolution predictions (unless `--no_hdf5`)
+
+With `--merge`, the per-chromosome files are concatenated and removed, leaving:
+
+- `<out_prefix>.variant_scores.tsv` — scores for all variants across all chromosomes
+- `<out_prefix>.variant_predictions.h5` — concatenated predictions (unless `--no_hdf5`), with structure:
+  - `observed/allele1_pred_counts`: shape `(N variants,)`
+  - `observed/allele2_pred_counts`: shape `(N variants,)`
+  - `observed/allele1_pred_profiles`: shape `(N variants, output_len)` — model logits
+  - `observed/allele2_pred_profiles`: shape `(N variants, output_len)` — model logits
 
 
 ## 2. Summarize variant scores across model folds: `variant_summary_across_folds.py`

--- a/README.md
+++ b/README.md
@@ -123,6 +123,46 @@ We provide several additional metrics that are computed as the product of the ab
 *__NOTE__*: For profile predictions, the saved arrays consist of model logits, not probabilities. This allows for averaging profile predictions across folds more easily, by averaging logits over folds and then taking the softmax (see [`variant-scorer/pull/23`](https://github.com/kundajelab/variant-scorer/pull/23)).
 
 
+### Null model and p-values
+
+P-values are computed empirically by comparing observed scores against a **dinucleotide-shuffled null distribution**. For each shuffled replicate, the flanking sequences around a variant are shuffled while preserving dinucleotide frequencies (using `dinuc_shuffle` from DeepLIFT), and the alleles themselves are left unchanged. This breaks local sequence context while keeping the same base composition, providing a null model for what scores would look like if the variant's surrounding sequence had no structured signal.
+
+#### Controlling the null distribution
+
+- `--num_shuf N` (default: 10): Generate N shuffled replicates per variant. Total shuffles = N × number of variants.
+- `--total_shuf T`: Generate exactly T shuffles total, sampled from the variant list (with replacement). Overrides `--num_shuf`.
+- `--shuffled_scores FILE`: Provide pre-computed shuffled scores from a previous run. The pipeline will reuse them if the variant IDs match, avoiding redundant compute.
+
+Larger N/T yields a finer-grained null distribution and more precise p-values, at the cost of additional compute.
+
+#### P-value computation
+
+P-values are rank-based: for each observed score, its p-value is `(rank in null + 1) / (N shuffles + 1)`. Tests are one- or two-tailed depending on the metric:
+
+| Column | Test |
+|---|---|
+| `logfc.pval` | two-tailed |
+| `abs_logfc.pval` | one-tailed (right) |
+| `jsd.pval` | one-tailed (right) |
+| `logfc_x_jsd.pval` | two-tailed |
+| `abs_logfc_x_jsd.pval` | one-tailed (right) |
+
+When peaks are provided (`--peaks`), the following are also computed:
+
+| Column | Test |
+|---|---|
+| `active_allele_quantile.pval` | one-tailed (right) |
+| `quantile_change.pval` | two-tailed |
+| `abs_quantile_change.pval` | one-tailed (right) |
+| `logfc_x_active_allele_quantile.pval` | two-tailed |
+| `abs_logfc_x_active_allele_quantile.pval` | one-tailed (right) |
+| `jsd_x_active_allele_quantile.pval` | one-tailed (right) |
+| `logfc_x_jsd_x_active_allele_quantile.pval` | two-tailed |
+| `abs_logfc_x_jsd_x_active_allele_quantile.pval` | one-tailed (right) |
+
+P-value columns are absent from the output if no shuffled scores were computed (i.e., `--num_shuf 0` and no `--shuffled_scores`).
+
+
 ### Per-chromosome scoring for large variant sets: `variant_scoring.per_chrom.py`
 
 For large variant lists, `variant_scoring.per_chrom.py` runs scoring per chromosome, which allows for parallelization and lower memory usage.

--- a/src/utils/merge.py
+++ b/src/utils/merge.py
@@ -1,0 +1,48 @@
+import os
+import numpy as np
+import h5py
+
+
+def merge_h5_predictions(chrom_h5_files, merged_h5_file):
+    """Read per-chromosome prediction H5 files and concatenate into one merged file.
+
+    Reads allele1_pred_counts, allele2_pred_counts, allele1_pred_profiles, and
+    allele2_pred_profiles from each file's 'observed' group, concatenates them, and
+    writes the result to merged_h5_file. Each per-chromosome file is deleted after reading.
+
+    Args:
+        chrom_h5_files: ordered list of paths to per-chromosome H5 files
+        merged_h5_file: path for the output merged H5 file
+    """
+    allele1_pred_counts = []
+    allele2_pred_counts = []
+    allele1_pred_profiles = []
+    allele2_pred_profiles = []
+
+    for chrom_preds_file in chrom_h5_files:
+        if os.path.isfile(chrom_preds_file):
+            with h5py.File(chrom_preds_file, 'r') as chrom_h5:
+                if 'observed' in chrom_h5:
+                    observed = chrom_h5['observed']
+                    if 'allele1_pred_counts' in observed:
+                        allele1_pred_counts.append(observed['allele1_pred_counts'][:])
+                    if 'allele2_pred_counts' in observed:
+                        allele2_pred_counts.append(observed['allele2_pred_counts'][:])
+                    if 'allele1_pred_profiles' in observed:
+                        allele1_pred_profiles.append(observed['allele1_pred_profiles'][:])
+                    if 'allele2_pred_profiles' in observed:
+                        allele2_pred_profiles.append(observed['allele2_pred_profiles'][:])
+                    print(f"Removing {chrom_preds_file}...")
+                    os.remove(chrom_preds_file)
+                else:
+                    print(f"Warning: 'observed' group not found in {chrom_preds_file}, skipping")
+        else:
+            print(f"Warning: {chrom_preds_file} not found, skipping")
+
+    if allele1_pred_counts and allele2_pred_counts and allele1_pred_profiles and allele2_pred_profiles:
+        with h5py.File(merged_h5_file, 'w') as merged_h5:
+            observed = merged_h5.create_group('observed')
+            observed.create_dataset('allele1_pred_counts', data=np.concatenate(allele1_pred_counts), compression='gzip', compression_opts=9)
+            observed.create_dataset('allele2_pred_counts', data=np.concatenate(allele2_pred_counts), compression='gzip', compression_opts=9)
+            observed.create_dataset('allele1_pred_profiles', data=np.concatenate(allele1_pred_profiles), compression='gzip', compression_opts=9)
+            observed.create_dataset('allele2_pred_profiles', data=np.concatenate(allele2_pred_profiles), compression='gzip', compression_opts=9)

--- a/src/variant_scoring.per_chrom.py
+++ b/src/variant_scoring.per_chrom.py
@@ -5,6 +5,7 @@ import h5py
 from utils import argmanager
 from utils.helpers import *
 from utils.io import *
+from utils.merge import merge_h5_predictions
 
 
 def main():
@@ -355,7 +356,10 @@ def main():
 
     # merge all per-chromosome predictions if requested
     if args.merge:
-        print("Merging all per-chromosome predictions...")
+        
+        # Handle scores
+        print("Merging all per-chromosome scores...")
+
         merged_dfs = []
         
         for chrom in todo_chroms:
@@ -378,7 +382,16 @@ def main():
             print(f"Merged scores for {len(merged_dfs)} chromosomes into {merged_file}")
             print(f"Total variants: {len(merged_df)}")
         else:
-            print("No chromosome files found to merge")
+            print("No chromosome score files found to merge")
+
+        # Handle prediction hdf5s
+        if not args.no_hdf5:
+
+            print("Merging all per-chromosome predictions...")
+
+            chrom_h5_files = ['.'.join([args.out_prefix, str(chrom), "variant_predictions.h5"]) for chrom in todo_chroms]
+            merged_h5_file = '.'.join([args.out_prefix, "variant_predictions.h5"])
+            merge_h5_predictions(chrom_h5_files, merged_h5_file)
 
     print("DONE")
     print()

--- a/tests/test_variant_scoring.py
+++ b/tests/test_variant_scoring.py
@@ -3,7 +3,10 @@ import subprocess
 import tempfile
 import os
 import sys
+import importlib.util
+import numpy as np
 import pandas as pd
+import h5py
 from pathlib import Path
 
 class TestVariantScoringCLI:
@@ -248,7 +251,7 @@ class TestVariantScoringCLI:
 	@pytest.mark.gpu
 	@pytest.mark.oak
 	def test_merge_chroms(self, out_dir, script_path_per_chrom, test_data_dir, genome_path, model_paths, chrom_sizes_path):
-		"""Test variant_scoring.per_chrom.py with real genome/model data (requires env vars and GPU)"""
+		"""Test variant_scoring.per_chrom.py merges scores/predictions successfully with real genome/model data (requires env vars and GPU)"""
 		if not os.path.exists(script_path_per_chrom):
 			pytest.skip(f"Script {script_path_per_chrom} not found")
 		
@@ -260,12 +263,9 @@ class TestVariantScoringCLI:
 		input_df = pd.read_csv(test_variants, sep='\t', header=None)
 		chrms = input_df[0].unique()
 
-		# Dictionary of number of variants per chromosome
-		variant_counts = input_df[0].value_counts().to_dict()
-
 		# Run for fold 0
 		model_path = model_paths[0]
-		output_prefix = os.path.join(out_dir, f"merged_fold_0")
+		output_prefix = os.path.join(out_dir, f"with_merge_fold_0")
 
 		cmd = [
 			sys.executable, script_path_per_chrom,
@@ -276,7 +276,6 @@ class TestVariantScoringCLI:
 			'--chrom_sizes', chrom_sizes_path,
 			'--num_shuf', '2',  # Use a small number for testing
 			'--schema', 'chrombpnet',
-			'--no_hdf5',  # Skip HDF5 output for faster testing
 			"--merge"
 		]
 			
@@ -289,7 +288,7 @@ class TestVariantScoringCLI:
 		# Check if it completed successfully
 		assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-		# Load file
+		# Load variant scores
 		output_file = f"{output_prefix}.variant_scores.tsv"
 		df = pd.read_csv(output_file, sep='\t')
 
@@ -299,3 +298,92 @@ class TestVariantScoringCLI:
 		# Check number of variants
 		input_df = pd.read_csv(test_variants, sep='\t', header=None)
 		assert len(df) == len(input_df), "Merged output has different number of variants than input"
+
+		# Load predictions & check h5 format and shape
+		output_h5 = f"{output_prefix}.variant_predictions.h5"
+		with h5py.File(output_h5, 'r') as f:
+			
+			assert "observed" in f, "No 'observed' group in predictions file"
+			observed = f["observed"]
+			assert "allele1_pred_counts" in observed, "No 'allele1_pred_counts' dataset in predictions file"
+			assert "allele2_pred_counts" in observed, "No 'allele2_pred_counts' dataset in predictions file"
+			assert "allele1_pred_profiles" in observed, "No 'allele1_pred_profiles' dataset in predictions file"
+			assert "allele2_pred_profiles" in observed, "No 'allele2_pred_profiles' dataset in predictions file"
+
+			assert observed["allele1_pred_counts"].shape[0] == len(df), f"Predictions have {observed['allele1_pred_counts'].shape[0]} variants, expected {len(df)}"
+			assert observed["allele1_pred_profiles"].shape[0] == len(df), f"Predictions have {observed['allele1_pred_profiles'].shape[0]} variants, expected {len(df)}"
+
+
+class TestMergeH5Predictions:
+	"""Unit tests for merge_h5_predictions() — no GPU or Oak data required."""
+
+	@pytest.fixture(scope="class")
+	def merge_fn(self, src):
+		"""Import merge_h5_predictions from utils.merge."""
+		spec = importlib.util.spec_from_file_location(
+			"merge",
+			os.path.join(src, "utils", "merge.py")
+		)
+		mod = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(mod)
+		return mod.merge_h5_predictions
+
+	def _write_chrom_h5(self, path, n_variants, profile_len=100):
+		"""Write a synthetic per-chromosome H5 in the expected format."""
+		with h5py.File(path, 'w') as f:
+			obs = f.create_group('observed')
+			obs.create_dataset('allele1_pred_counts',  data=np.random.rand(n_variants))
+			obs.create_dataset('allele2_pred_counts',  data=np.random.rand(n_variants))
+			obs.create_dataset('allele1_pred_profiles', data=np.random.rand(n_variants, profile_len))
+			obs.create_dataset('allele2_pred_profiles', data=np.random.rand(n_variants, profile_len))
+
+	def test_merge_combines_chroms(self, merge_fn, tmp_path):
+		"""Merged file contains all four datasets concatenated across chromosomes."""
+		counts = [5, 7, 3]
+		chrom_files = []
+		for i, n in enumerate(counts):
+			p = str(tmp_path / f"out.chr{i+1}.variant_predictions.h5")
+			self._write_chrom_h5(p, n)
+			chrom_files.append(p)
+
+		merged = str(tmp_path / "out.variant_predictions.h5")
+		merge_fn(chrom_files, merged)
+
+		total = sum(counts)
+		with h5py.File(merged, 'r') as f:
+			assert 'observed' in f
+			obs = f['observed']
+			for key in ['allele1_pred_counts', 'allele2_pred_counts',
+						'allele1_pred_profiles', 'allele2_pred_profiles']:
+				assert key in obs, f"Missing dataset: {key}"
+			assert obs['allele1_pred_counts'].shape[0]   == total
+			assert obs['allele2_pred_counts'].shape[0]   == total
+			assert obs['allele1_pred_profiles'].shape[0] == total
+			assert obs['allele2_pred_profiles'].shape[0] == total
+
+	def test_merge_deletes_chrom_files(self, merge_fn, tmp_path):
+		"""Per-chromosome H5 files are deleted after merging."""
+		counts = [4, 6]
+		chrom_files = []
+		for i, n in enumerate(counts):
+			p = str(tmp_path / f"del.chr{i+1}.variant_predictions.h5")
+			self._write_chrom_h5(p, n)
+			chrom_files.append(p)
+
+		merged = str(tmp_path / "del.variant_predictions.h5")
+		merge_fn(chrom_files, merged)
+
+		for f in chrom_files:
+			assert not os.path.exists(f), f"Expected {f} to be deleted after merge"
+
+	def test_merge_missing_file_skipped(self, merge_fn, tmp_path):
+		"""A missing per-chrom file is skipped gracefully and the rest are merged."""
+		p_exists = str(tmp_path / "skip.chr1.variant_predictions.h5")
+		p_missing = str(tmp_path / "skip.chr2.variant_predictions.h5")
+		self._write_chrom_h5(p_exists, 5)
+
+		merged = str(tmp_path / "skip.variant_predictions.h5")
+		merge_fn([p_exists, p_missing], merged)
+
+		with h5py.File(merged, 'r') as f:
+			assert f['observed']['allele1_pred_counts'].shape[0] == 5


### PR DESCRIPTION
- **H5 merge for per-chromosome scoring**: `--merge` in `variant_scoring.per_chrom.py` now also concatenates per-chromosome HDF5 prediction files into a single <out_prefix>.variant_predictions.h5, in addition to merging the TSV score files. The merged H5 contains four datasets under an observed group: `allele1_pred_counts`, `allele2_pred_counts`, `allele1_pred_profiles`, `allele2_pred_profiles`.
- **Refactor**: extracted the H5 merge logic from `main()` into a standalone function `merge_h5_predictions()` in `src/utils/merge.py`. This module only depends on os, numpy, and h5py, making it importable in lightweight environments without triggering the TensorFlow import chain.
- **Tests**: added TestMergeH5Predictions in tests/test_variant_scoring.py — three unit tests using synthetic H5 files that run without GPU or Oak access:
  - `test_merge_combines_chroms`: verifies all four datasets are present with the correct concatenated shape
  - `test_merge_deletes_chrom_files`: verifies per-chrom files are removed after merging
  - `test_merge_missing_file_skipped`: verifies a missing per-chrom file is skipped gracefully and the rest are still merged
  - Also updated the existing `test_merge_chroms` integration test to validate the H5 output structure (requires GPU + Oak).
- **Bug fix**: the `test_merge_chroms` assertion messages referenced an undefined shape variable; fixed to `observed['allele1_pred_counts'].shape[0]` and `observed['allele1_pred_profiles'].shape[0]`.
- **Docs**: expanded README with:
  1. a per-chromosome scoring subsection documenting `--merge`, `--no_hdf5`, and the merged H5 dataset structure
  2. a null model and p-values subsection explaining dinucleotide shuffling, how to control the null distribution (`--num_shuf`, --total_shuf, `--shuffled_scores`), the rank-based p-value formula, and tables of all .pval output columns with their tail directions
  3. fixed a duplicate `--no_hdf5` entry in the args list.